### PR TITLE
Decimal Precision Feature 

### DIFF
--- a/common/src/main/java/me/zacharias/speedometer/Client.java
+++ b/common/src/main/java/me/zacharias/speedometer/Client.java
@@ -1,30 +1,32 @@
 package me.zacharias.speedometer;
 
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+
 import com.mojang.blaze3d.platform.InputConstants;
+
 import dev.architectury.event.events.client.ClientGuiEvent;
 import dev.architectury.event.events.client.ClientTickEvent;
 import dev.architectury.platform.Platform;
 import dev.architectury.platform.client.ConfigurationScreenRegistry;
 import dev.architectury.registry.client.keymappings.KeyMappingRegistry;
+import static me.zacharias.speedometer.Speedometer.ICON;
+import static me.zacharias.speedometer.Speedometer.LOGGER;
+import static me.zacharias.speedometer.Speedometer.MOD_ID;
+import static me.zacharias.speedometer.Speedometer.VERSION;
 import net.minecraft.ChatFormatting;
-import net.minecraft.CrashReport;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.vehicle.boat.Boat;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.network.chat.Component;
 import net.objecthunter.exp4j.ExpressionBuilder;
-
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.util.*;
-
-import static me.zacharias.speedometer.Speedometer.*;
 
 public class Client {
     public static final KeyMapping.Category SPEEDOMETER_KEY_CATEGORY = KeyMapping.Category.register(Identifier.fromNamespaceAndPath(MOD_ID, "name"));
@@ -143,7 +145,7 @@ public class Client {
             speedTypeSpeed = speed;
         }
 
-        String format = String.format("%.2f", speedTypeSpeed);
+        String format = String.format("%." + Config.getSpeedPrecision() + "f", speedTypeSpeed);
 
         String speedString = format + " " + SpeedTypes.getName(speedType).getString();
 

--- a/common/src/main/java/me/zacharias/speedometer/Config.java
+++ b/common/src/main/java/me/zacharias/speedometer/Config.java
@@ -1,14 +1,21 @@
 package me.zacharias.speedometer;
 
-import dev.architectury.platform.Platform;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.*;
-
-import static me.zacharias.speedometer.Speedometer.*;
+import dev.architectury.platform.Platform;
+import static me.zacharias.speedometer.Speedometer.LOGGER;
+import static me.zacharias.speedometer.Speedometer.MOD_ID;
+import static me.zacharias.speedometer.Speedometer.formatMillisToDHMS;
 
 public class Config {
     private static JSONObject config;
@@ -26,6 +33,8 @@ public class Config {
 
     public static final int MIN_IMAGE_SIZE = 10;
     public static final int MAX_IMAGE_SIZE = 200;
+    public static final int MIN_SPEED_PRECISION = 0;
+    public static final int MAX_SPEED_PRECISION = 5;
 
     public static void initialize(){
         if(config != null) throw new RuntimeException("Already Initialized");
@@ -196,6 +205,14 @@ public class Config {
             LOGGER.warn("Speed average sample count is missing or invalid, resetting to default value");
             config.put("speedAvrageSampleCount", 100);
         }
+
+        if(!(config.has("speedPrecision") && config.get("speedPrecision") instanceof Number &&
+                config.getInt("speedPrecision") >= MIN_SPEED_PRECISION &&
+                config.getInt("speedPrecision") <= MAX_SPEED_PRECISION))
+        {
+            LOGGER.warn("Speed precision is missing or invalid, resetting to default value");
+            config.put("speedPrecision", 2);
+        }
         
         LOGGER.info("Validated config successfully");
     }
@@ -263,6 +280,10 @@ public class Config {
 
         if(!config.has("speedAvrageSampleCount")) {
             config.put("speedAvrageSampleCount", 150);
+        }
+
+        if(!config.has("speedPrecision")) {
+            config.put("speedPrecision", 2);
         }
 
         warns = 0;
@@ -419,6 +440,18 @@ public class Config {
         return warns;
     }
 
+    public static int getSpeedPrecision()
+    {
+        if(config.has("speedPrecision"))
+        {
+            return Math.max(MIN_SPEED_PRECISION, Math.min(MAX_SPEED_PRECISION, config.getInt("speedPrecision")));
+        }
+        else
+        {
+            return 2;
+        }
+    }
+
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Config Setters">
@@ -479,6 +512,11 @@ public class Config {
     public static void setSpeedAvrageSampleCount(int speedAvrageSampleCount)
     {
         config.put("speedAvrageSampleCount", speedAvrageSampleCount);
+    }
+
+    public static void setSpeedPrecision(int speedPrecision)
+    {
+        config.put("speedPrecision", Math.max(MIN_SPEED_PRECISION, Math.min(MAX_SPEED_PRECISION, speedPrecision)));
     }
 
     public static void IncrementWarnCount() {

--- a/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
+++ b/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
@@ -47,7 +47,12 @@ public class ConfigMenu {
     );
 
     Integer[] speedPrecisionValues = new Integer[] { // 0 to 5
-        Config.MIN_SPEED_PRECISION, 2, 3, 4, Config.MAX_SPEED_PRECISION
+        Config.MIN_SPEED_PRECISION, 
+        Config.MIN_SPEED_PRECISION + 1, 
+        Config.MIN_SPEED_PRECISION + 2, 
+        Config.MIN_SPEED_PRECISION + 3, 
+        Config.MIN_SPEED_PRECISION + 4, 
+        Config.MAX_SPEED_PRECISION
     };
 
     category.addEntry(entryBuilder.startSelector(

--- a/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
+++ b/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
@@ -1,6 +1,7 @@
 package me.zacharias.speedometer;
 
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;
@@ -46,14 +47,7 @@ public class ConfigMenu {
         .build()
     );
 
-    Integer[] speedPrecisionValues = new Integer[] { // 0 to 5
-        Config.MIN_SPEED_PRECISION, 
-        Config.MIN_SPEED_PRECISION + 1, 
-        Config.MIN_SPEED_PRECISION + 2, 
-        Config.MIN_SPEED_PRECISION + 3, 
-        Config.MIN_SPEED_PRECISION + 4, 
-        Config.MAX_SPEED_PRECISION
-    };
+    Integer[] speedPrecisionValues = IntStream.rangeClosed(Config.MIN_SPEED_PRECISION, Config.MAX_SPEED_PRECISION).boxed().toArray(Integer[]::new);
 
     category.addEntry(entryBuilder.startSelector(
         Component.translatable("speedometer.config.speed_precision"),

--- a/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
+++ b/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
@@ -1,17 +1,19 @@
 package me.zacharias.speedometer;
 
-import me.shedaniel.clothconfig2.api.*;
-import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.Component;
-import net.objecthunter.exp4j.ExpressionBuilder;
-import net.objecthunter.exp4j.Expression;
-
 import java.util.Optional;
 
-import static me.zacharias.speedometer.Config.yRegex;
-import static me.zacharias.speedometer.Config.xRegex;
-import static me.zacharias.speedometer.Config.MIN_IMAGE_SIZE;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import me.shedaniel.clothconfig2.api.Requirement;
 import static me.zacharias.speedometer.Config.MAX_IMAGE_SIZE;
+import static me.zacharias.speedometer.Config.MAX_SPEED_PRECISION;
+import static me.zacharias.speedometer.Config.MIN_IMAGE_SIZE;
+import static me.zacharias.speedometer.Config.MIN_SPEED_PRECISION;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.objecthunter.exp4j.Expression;
+import net.objecthunter.exp4j.ExpressionBuilder;
 
 public class ConfigMenu {
 
@@ -43,6 +45,22 @@ public class ConfigMenu {
 
     category.addEntry(entryBuilder.startIntSlider(Component.translatable("speedometer.config.average_speed_sample_count"), me.zacharias.speedometer.Config.getSpeedAvrageSampleCount(), 30, 500)
         .setSaveConsumer(me.zacharias.speedometer.Config::setSpeedAvrageSampleCount)
+        .build()
+    );
+
+    Integer[] speedPrecisionValues = new Integer[] { 
+        0, 2, 3, 4, 5
+    };
+
+    category.addEntry(entryBuilder.startSelector(
+        Component.translatable("speedometer.config.speed_precision"),
+        speedPrecisionValues,
+        me.zacharias.speedometer.Config.getSpeedPrecision()
+    )
+        .setDefaultValue(2)
+        .setNameProvider(value -> Component.literal(String.valueOf(value)))
+        .setSaveConsumer(me.zacharias.speedometer.Config::setSpeedPrecision)
+        .setTooltip(Component.translatable("speedometer.config.tooltip.speed_precision"))
         .build()
     );
 

--- a/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
+++ b/common/src/main/java/me/zacharias/speedometer/ConfigMenu.java
@@ -7,9 +7,7 @@ import me.shedaniel.clothconfig2.api.ConfigCategory;
 import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
 import me.shedaniel.clothconfig2.api.Requirement;
 import static me.zacharias.speedometer.Config.MAX_IMAGE_SIZE;
-import static me.zacharias.speedometer.Config.MAX_SPEED_PRECISION;
 import static me.zacharias.speedometer.Config.MIN_IMAGE_SIZE;
-import static me.zacharias.speedometer.Config.MIN_SPEED_PRECISION;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.objecthunter.exp4j.Expression;
@@ -48,8 +46,8 @@ public class ConfigMenu {
         .build()
     );
 
-    Integer[] speedPrecisionValues = new Integer[] { 
-        0, 2, 3, 4, 5
+    Integer[] speedPrecisionValues = new Integer[] { // 0 to 5
+        Config.MIN_SPEED_PRECISION, 2, 3, 4, Config.MAX_SPEED_PRECISION
     };
 
     category.addEntry(entryBuilder.startSelector(

--- a/common/src/main/resources/assets/speedometer/lang/en_us.json
+++ b/common/src/main/resources/assets/speedometer/lang/en_us.json
@@ -17,6 +17,7 @@
   "speedometer.config.showSpeedType": "Show Visual Speed Type",
   "speedometer.config.override_color": "Override color",
   "speedometer.config.average_speed_sample_count": "Average Speed Sample Count",
+  "speedometer.config.speed_precision": "Speed Decimal Precision",
 
   "key.speedometer.configKey": "Config Key",
   "key.speedometer.debugKey": "Debug Key",
@@ -64,6 +65,7 @@
 
   "speedometer.config.tooltip.override_color.line1": "Override the color of a line pointer",
   "speedometer.config.tooltip.override_color.line2": "OPS doesn't work if the pointer is an image!",
+  "speedometer.config.tooltip.speed_precision": "Number of digits shown after the decimal point",
 
   "speedometer.invalid": "Invalid, or Empty String",
 

--- a/common/src/main/resources/assets/speedometer/lang/sv_se.json
+++ b/common/src/main/resources/assets/speedometer/lang/sv_se.json
@@ -65,7 +65,7 @@
 
     "speedometer.config.tooltip.override_color.line1": "Överskrider förgen av linjen pekaren",
     "speedometer.config.tooltip.override_color.line2": "OBS funkar inte om pekaren är en bild!",
-    "speedometer.config.tooltip.speed_precision": "Antal siffror som visas efter decimaltecknet",
+    "speedometer.config.tooltip.speed_precision": "Antal decimaler efter decimaltecknet",
   
     "speedometer.invalid": "Ogiltig eller Inte korrekt Sträng",
 

--- a/common/src/main/resources/assets/speedometer/lang/sv_se.json
+++ b/common/src/main/resources/assets/speedometer/lang/sv_se.json
@@ -17,6 +17,7 @@
     "speedometer.config.showSpeedType": "Visa Visuell Farttyp",
     "speedometer.config.override_color": "Överskrid färgen",
     "speedometer.config.average_speed_sample_count": "Antal prover för medelhastighet",
+    "speedometer.config.speed_precision": "Decimalprecision för hastighet",
 
     "key.speedometer.configKey": "Konfigurations Knapp",
     "key.speedometer.debugKey": "Debug Knapp",
@@ -64,6 +65,7 @@
 
     "speedometer.config.tooltip.override_color.line1": "Överskrider förgen av linjen pekaren",
     "speedometer.config.tooltip.override_color.line2": "OBS funkar inte om pekaren är en bild!",
+    "speedometer.config.tooltip.speed_precision": "Antal siffror som visas efter decimaltecknet",
   
     "speedometer.invalid": "Ogiltig eller Inte korrekt Sträng",
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=26.2
 fabric.loom.disableObfuscation=true
 
 archives_base_name=speedometer
-mod_version=6.4.3
+mod_version=6.4.4
 maven_group=me.zacharias
 
 # https://modrinth.com/mod/architectury-api/versions


### PR DESCRIPTION
Your mod is kinda useful, but I was checking speed for some advanced farms, and found out that the only way to get advanced precision values (at stabilized speeds) was to activate debug mode, which is imo a bit overkill.

I added to the config a button to increase or decrease the decimal precision value, up to 5 digits after the decimal point.
The default value is set to `2`, like before.

I tested it on both `NeoForge` & `Fabric`.
Both builds are okay, but the main Gradle build was already broken on master, I haven't fixed it.

> /!\ ***I've made the translation for the sweden internationalization using AI (claude)***

Note: I have some comments / suggestions about the mod in general...
- Default values: one of the useful points of `ClothConfigApi` is the default values, allowing the use of the `Reset` button on the config panel. However, it's currently not implemented. I've implemented it for my feature, but I want your "agreement" before extending it.
- Marking `ClothConfigApi` as mandatory for the `Fabric` version, as it's already the case for the `NeoForge` one, I may be missing some info, but I don't understand the diff.
- In the `fabric.mod.json`, the line specifying the cloth-config version is `cloth-config1`. Is that intended ?
- It looks like on the `NeoForge` Modrinth release you forgot to add the dependencies. It's not a major issue since Forge errors are self-explanatory, but it would be great to have it specified automatically :)

*/!\ I've increased the version number, but I don't know your version convention, so I'l let you check that.**